### PR TITLE
Associar o cartão criado com a proposta

### DIFF
--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/PropostaApplication.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/PropostaApplication.java
@@ -3,9 +3,11 @@ package br.com.zupacademy.ggwadera.proposta;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class PropostaApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/AssociaCartao.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/AssociaCartao.java
@@ -1,0 +1,51 @@
+package br.com.zupacademy.ggwadera.proposta.cartao;
+
+import br.com.zupacademy.ggwadera.proposta.proposta.EstadoProposta;
+import br.com.zupacademy.ggwadera.proposta.proposta.Proposta;
+import br.com.zupacademy.ggwadera.proposta.proposta.PropostaRepository;
+import feign.FeignException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class AssociaCartao {
+
+  private final Logger logger = LoggerFactory.getLogger(AssociaCartao.class);
+  private final PropostaRepository propostaRepository;
+  private final CartaoClient cartaoClient;
+
+  @Autowired
+  public AssociaCartao(PropostaRepository propostaRepository, CartaoClient cartaoClient) {
+    this.propostaRepository = propostaRepository;
+    this.cartaoClient = cartaoClient;
+  }
+
+  @Scheduled(fixedDelay = 5000)
+  @Transactional
+  public void associarCartao() {
+    logger.info("Verificando cartões para propostas");
+    List<Proposta> propostasParaSalvar =
+        propostaRepository.findByIdCartaoIsNullAndEstadoIs(EstadoProposta.ELEGIVEL).parallelStream()
+            .peek(
+                proposta -> {
+                  try {
+                    CartaoResponse cartao = cartaoClient.getCartao(proposta.getId());
+                    proposta.setIdCartao(cartao.getId());
+                    logger.info("Proposta id={} atualizada com cartão", proposta.getId());
+                  } catch (FeignException e) {
+                    logger.info("Proposta id={} ainda não tem cartão", proposta.getId());
+                  }
+                })
+            .collect(
+                Collectors.filtering(
+                    proposta -> proposta.getIdCartao() != null, Collectors.toList()));
+    propostaRepository.saveAll(propostasParaSalvar);
+  }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoClient.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoClient.java
@@ -1,0 +1,14 @@
+package br.com.zupacademy.ggwadera.proposta.cartao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "cartoes", url = "${servicos.contas}")
+public interface CartaoClient {
+
+  @GetMapping("/cartoes?idProposta={idProposta}")
+  CartaoResponse getCartao(@PathVariable("idProposta") UUID idProposta);
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoResponse.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoResponse.java
@@ -1,0 +1,13 @@
+package br.com.zupacademy.ggwadera.proposta.cartao;
+
+public class CartaoResponse {
+  private String id;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/proposta/Proposta.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/proposta/Proposta.java
@@ -14,6 +14,9 @@ public class Proposta {
 
   @Id @GeneratedValue private UUID id;
 
+  @Column(unique = true)
+  private String idCartao;
+
   @Column(nullable = false, unique = true)
   private String documento;
 
@@ -68,8 +71,16 @@ public class Proposta {
     return salario;
   }
 
+  public String getIdCartao() {
+    return idCartao;
+  }
+
   public void setEstado(EstadoProposta estado) {
     this.estado = estado;
+  }
+
+  public void setIdCartao(String idCartao) {
+    this.idCartao = idCartao;
   }
 
   @Override

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/proposta/PropostaRepository.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/proposta/PropostaRepository.java
@@ -1,7 +1,13 @@
 package br.com.zupacademy.ggwadera.proposta.proposta;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
+
+import java.util.List;
 
 public interface PropostaRepository extends JpaRepository<Proposta, Long> {
+
   boolean existsByDocumento(String documento);
+
+  List<Proposta> findByIdCartaoIsNullAndEstadoIs(@NonNull EstadoProposta estado);
 }


### PR DESCRIPTION
### Objetivo

Atrelar o número do cartão gerado a proposta. A proposta quando aprovada deve ser relacionada com um número do cartão.

O sistema de proposta deve consultar em tempo periódico o sistema de cartões a fim de obter o número do cartão gerada 
para as propostas que foram geradas com sucesso, porém ainda não tem o número do cartão atrelado.

### Necessidades

Associar o número do cartão na proposta previamente criada com sucesso. O cartão deve ser persistido de acordo com as 
informações recebidas do sistema externo.

### Restrições

Identificador da proposta será utilizado como base para consulta do cartão no sistema legado "accounts".

Para consultar se o cartão foi criado com sucesso, temos uma API específica para este fim, vamos analisá-la?

`http://localhost:8888/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/`

### Resultado Esperado

- Quando o sistema de accounts(cartões) retornar sucesso (status code na faixa 200) o número de cartão deve ser atrelado a proposta.
    - O **número do carto** é o **id** do cartão retornado na resposta do sistema de accounts(cartões)

- Quando o sistema de accounts(cartões) retornar falha (status code na faixa 400 ou 500) não atualizar o estado da proposta, pois ainda não foi processado, aguardar próxima interação.