### PR TITLE
configuração keycloak para autorização

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,18 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-jose</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/security/WebSecurityConfig.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/security/WebSecurityConfig.java
@@ -1,0 +1,19 @@
+package br.com.zupacademy.ggwadera.proposta.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+
+@Configuration
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http.authorizeRequests()
+        .anyRequest()
+        .authenticated()
+        .and()
+        .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,14 +7,19 @@ spring:
   h2:
     console:
       enabled: true
-
   jpa:
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
         format_sql: true
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:18080/auth/realms/nosso-cartao}
+          jwk-set-uri: ${KEYCLOAK_JWKS_URI:http://localhost:18080/auth/realms/nosso-cartao/protocol/openid-connect/certs}
 
 servicos:
   analise: ${URL_ANALISE:http://localhost:9999/api}


### PR DESCRIPTION
### Contexto

Controlar autenticação e autorização é um tarefa complicada e que na maioria das vezes envolve um conhecimento profundo em 
segurança, como por exemplo se preocupar com vulnerabilidades de segurança, trazer essa responsabilidade para nossa solução 
pode trazer muitas complicações.

Vamos deixar essas características para uma outra aplicação um IAM (Identity and Access Management).

### Objetivo

Realizar a integração do nosso sistema com o Keycloak, a fim de proteger nossas APIs.

### Necessidades

Precisamos configurar nosso sistema para se comunicar com nosso servidor de autenticação.

### Restrições

* Não vamos realizar a manipulação de usuários, então não podemos criar nenhum usuário no sistema.

* Antes de começarmos a configuração na nossa aplicação vamos precisar realizar algumas tarefas

  * Logar no Keycloak nosso Servidor de IAM,

  * Nosso próximo passo será criar um "espaço" para colocar nossas permissões, no keycloak esse "espaço" chama-se Realm,

    * Criar usuários para realizar logins na plataforma

### Resultado Esperado

Configuração do Spring Security na nossa aplicação com o módulo OAuth2 apontando para
o nosso servidor de Autorização, nesse caso o Keycloak.
