### PR TITLE
Associação do cartão com Paypal

### DIFF
--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/avisoviagem/AvisoViagemController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/avisoviagem/AvisoViagemController.java
@@ -3,14 +3,16 @@ package br.com.zupacademy.ggwadera.proposta.avisoviagem;
 import br.com.zupacademy.ggwadera.proposta.cartao.Cartao;
 import br.com.zupacademy.ggwadera.proposta.cartao.CartaoClient;
 import br.com.zupacademy.ggwadera.proposta.cartao.CartaoRepository;
+import br.com.zupacademy.ggwadera.proposta.cartao.CartaoUtils;
 import br.com.zupacademy.ggwadera.proposta.util.RequestInfo;
 import br.com.zupacademy.ggwadera.proposta.util.error.ApiErrorException;
+import br.com.zupacademy.ggwadera.proposta.util.validation.ExistsId;
 import feign.FeignException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,16 +42,10 @@ public class AvisoViagemController {
 
   @PostMapping("/cartoes/{id}/viagem")
   public ResponseEntity<Void> novoAvisoViagem(
-      @PathVariable String id,
+      @PathVariable @Validated @ExistsId(domainClass = Cartao.class) String id,
       @RequestBody @Valid AvisoViagemRequest dto,
       HttpServletRequest request) {
-    Cartao cartao =
-        cartaoRepository
-            .findById(id)
-            .orElseThrow(
-                () ->
-                    new ApiErrorException(
-                        HttpStatus.NOT_FOUND, "Não foi encontrado um cartão com este id"));
+    Cartao cartao = CartaoUtils.findByIdOrThrow(cartaoRepository, id);
     try {
       cartaoClient.avisoViagem(cartao.getId(), dto);
     } catch (FeignException e) {

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/biometria/BiometriaController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/biometria/BiometriaController.java
@@ -2,9 +2,8 @@ package br.com.zupacademy.ggwadera.proposta.biometria;
 
 import br.com.zupacademy.ggwadera.proposta.cartao.Cartao;
 import br.com.zupacademy.ggwadera.proposta.cartao.CartaoRepository;
-import br.com.zupacademy.ggwadera.proposta.util.error.ApiErrorException;
+import br.com.zupacademy.ggwadera.proposta.cartao.CartaoUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,13 +32,7 @@ public class BiometriaController {
       @PathVariable String id,
       @RequestBody @Valid NovaBiometriaRequest request,
       UriComponentsBuilder builder) {
-    Cartao cartao =
-        cartaoRepository
-            .findById(id)
-            .orElseThrow(
-                () ->
-                    new ApiErrorException(
-                        HttpStatus.NOT_FOUND, "Não foi encontrado um cartão com este id"));
+    Cartao cartao = CartaoUtils.findByIdOrThrow(cartaoRepository, id);
     Biometria biometria = biometriaRepository.save(request.toModel(cartao));
     URI uri = builder.path("/biometrias/{id}").buildAndExpand(biometria.getId()).toUri();
     return ResponseEntity.created(uri).build();

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoClient.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoClient.java
@@ -3,6 +3,8 @@ package br.com.zupacademy.ggwadera.proposta.cartao;
 import br.com.zupacademy.ggwadera.proposta.avisoviagem.AvisoViagemRequest;
 import br.com.zupacademy.ggwadera.proposta.cartao.bloqueio.RespostaBloqueio;
 import br.com.zupacademy.ggwadera.proposta.cartao.bloqueio.SolicitacaoBloqueio;
+import br.com.zupacademy.ggwadera.proposta.carteira.CarteiraRequest;
+import br.com.zupacademy.ggwadera.proposta.carteira.ResultadoCarteira;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,4 +22,8 @@ public interface CartaoClient {
 
   @PostMapping("/cartoes/{id}/avisos")
   void avisoViagem(@PathVariable("id") String id, @RequestBody AvisoViagemRequest body);
+
+  @PostMapping("/cartoes/{id}/carteiras")
+  ResultadoCarteira adicionaCarteira(
+      @PathVariable("id") String id, @RequestBody CarteiraRequest body);
 }

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoUtils.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/CartaoUtils.java
@@ -1,0 +1,16 @@
+package br.com.zupacademy.ggwadera.proposta.cartao;
+
+import br.com.zupacademy.ggwadera.proposta.util.error.ApiErrorException;
+import org.springframework.http.HttpStatus;
+
+public class CartaoUtils {
+
+  public static Cartao findByIdOrThrow(CartaoRepository repository, String id) {
+    return repository
+        .findById(id)
+        .orElseThrow(
+            () ->
+                new ApiErrorException(
+                    HttpStatus.NOT_FOUND, "Não foi encontrando um cartão com o id especificado"));
+  }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/bloqueio/BloqueioController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/cartao/bloqueio/BloqueioController.java
@@ -3,6 +3,7 @@ package br.com.zupacademy.ggwadera.proposta.cartao.bloqueio;
 import br.com.zupacademy.ggwadera.proposta.cartao.Cartao;
 import br.com.zupacademy.ggwadera.proposta.cartao.CartaoClient;
 import br.com.zupacademy.ggwadera.proposta.cartao.CartaoRepository;
+import br.com.zupacademy.ggwadera.proposta.cartao.CartaoUtils;
 import br.com.zupacademy.ggwadera.proposta.util.RequestInfo;
 import br.com.zupacademy.ggwadera.proposta.util.error.ApiErrorException;
 import feign.FeignException;
@@ -36,13 +37,7 @@ public class BloqueioController {
   @PostMapping("/cartoes/{id}/bloqueio")
   @Transactional
   public ResponseEntity<Void> bloqueiaCartao(@PathVariable String id, HttpServletRequest request) {
-    Cartao cartao =
-        cartaoRepository
-            .findById(id)
-            .orElseThrow(
-                () ->
-                    new ApiErrorException(
-                        HttpStatus.NOT_FOUND, "Não foi encontrado um cartão com este id"));
+    Cartao cartao = CartaoUtils.findByIdOrThrow(cartaoRepository, id);
     boolean cartaoFoiBloqueado;
     try {
       RespostaBloqueio response =

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/Carteira.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/Carteira.java
@@ -1,0 +1,44 @@
+package br.com.zupacademy.ggwadera.proposta.carteira;
+
+import br.com.zupacademy.ggwadera.proposta.cartao.Cartao;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Table(
+    indexes = {
+      @Index(name = "IDX_CARTEIRA_tipo_UNQ", columnList = "tipo, cartao_id", unique = true)
+    })
+@Entity
+public class Carteira {
+
+  @Id private UUID id;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private TipoCarteira tipo;
+
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
+  private Cartao cartao;
+
+  @Deprecated
+  public Carteira() {}
+
+  public Carteira(UUID id, TipoCarteira tipo, Cartao cartao) {
+    this.id = id;
+    this.tipo = tipo;
+    this.cartao = cartao;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public TipoCarteira getTipo() {
+    return tipo;
+  }
+
+  public Cartao getCartao() {
+    return cartao;
+  }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/CarteiraController.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/CarteiraController.java
@@ -1,0 +1,63 @@
+package br.com.zupacademy.ggwadera.proposta.carteira;
+
+import br.com.zupacademy.ggwadera.proposta.cartao.Cartao;
+import br.com.zupacademy.ggwadera.proposta.cartao.CartaoClient;
+import br.com.zupacademy.ggwadera.proposta.cartao.CartaoRepository;
+import br.com.zupacademy.ggwadera.proposta.cartao.CartaoUtils;
+import br.com.zupacademy.ggwadera.proposta.util.error.ApiErrorException;
+import feign.FeignException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+public class CarteiraController {
+
+  private final Logger logger = LoggerFactory.getLogger(CarteiraController.class);
+  private final CarteiraRepository carteiraRepository;
+  private final CartaoRepository cartaoRepository;
+  private final CartaoClient cartaoClient;
+
+  @Autowired
+  public CarteiraController(
+      CarteiraRepository carteiraRepository,
+      CartaoRepository cartaoRepository,
+      CartaoClient cartaoClient) {
+    this.carteiraRepository = carteiraRepository;
+    this.cartaoRepository = cartaoRepository;
+    this.cartaoClient = cartaoClient;
+  }
+
+  @PostMapping("/cartoes/{id}/carteiras")
+  public ResponseEntity<Void> adicionaCarteira(
+      @PathVariable String id,
+      @RequestBody @Valid CarteiraRequest request,
+      UriComponentsBuilder builder) {
+    Cartao cartao = CartaoUtils.findByIdOrThrow(cartaoRepository, id);
+    if (carteiraRepository.existsByTipoAndCartao(request.getCarteira(), cartao)) {
+      throw new ApiErrorException(
+          HttpStatus.UNPROCESSABLE_ENTITY,
+          "Já existe uma carteira desse tipo associada ao cartão solicitado");
+    }
+    try {
+      ResultadoCarteira resultado = cartaoClient.adicionaCarteira(id, request);
+      Carteira carteira = carteiraRepository.save(request.toModel(resultado.getId(), cartao));
+      logger.info("Nova carteira id={} tipo={}", carteira.getId(), carteira.getTipo());
+      URI uri = builder.path("/carteiras/{id}").buildAndExpand(carteira.getId()).toUri();
+      return ResponseEntity.created(uri).build();
+    } catch (FeignException e) {
+      logger.error("status={} erro={}", e.status(), e.contentUTF8());
+      throw new ApiErrorException(HttpStatus.BAD_GATEWAY, "Erro ao adicionar carteira");
+    }
+  }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/CarteiraRepository.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/CarteiraRepository.java
@@ -1,0 +1,10 @@
+package br.com.zupacademy.ggwadera.proposta.carteira;
+
+import br.com.zupacademy.ggwadera.proposta.cartao.Cartao;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CarteiraRepository extends JpaRepository<Carteira, UUID> {
+  boolean existsByTipoAndCartao(TipoCarteira tipo, Cartao cartao);
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/CarteiraRequest.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/CarteiraRequest.java
@@ -1,0 +1,32 @@
+package br.com.zupacademy.ggwadera.proposta.carteira;
+
+import br.com.zupacademy.ggwadera.proposta.cartao.Cartao;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
+
+public class CarteiraRequest {
+
+  @NotBlank @Email private final String email;
+
+  @NotNull private final TipoCarteira carteira;
+
+  public CarteiraRequest(String email, TipoCarteira carteira) {
+    this.email = email;
+    this.carteira = carteira;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public TipoCarteira getCarteira() {
+    return carteira;
+  }
+
+  public Carteira toModel(UUID id, Cartao cartao) {
+    return new Carteira(id, carteira, cartao);
+  }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/ResultadoCarteira.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/ResultadoCarteira.java
@@ -1,0 +1,21 @@
+package br.com.zupacademy.ggwadera.proposta.carteira;
+
+import java.util.UUID;
+
+public class ResultadoCarteira {
+  private final String resultado;
+  private final UUID id;
+
+  public ResultadoCarteira(String resultado, UUID id) {
+    this.resultado = resultado;
+    this.id = id;
+  }
+
+  public String getResultado() {
+    return resultado;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+}

--- a/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/TipoCarteira.java
+++ b/src/main/java/br/com/zupacademy/ggwadera/proposta/carteira/TipoCarteira.java
@@ -1,0 +1,6 @@
+package br.com.zupacademy.ggwadera.proposta.carteira;
+
+public enum TipoCarteira {
+  Paypal,
+  SamsungPay
+}


### PR DESCRIPTION
### Objetivo

Realizar a inclusão do nosso cartão na carteira digital Paypal.

### Necessidades

O portador do cartão deseja associar seu cartão a carteira digital do Paypal, para isso será necessário consumir a API 
do sistema bancário.

Temos uma API específica para cadastrar a carteira digital, vamos analisá-la?

`http://localhost:8888/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/`

### Restrições

Devemos criar uma API com as seguintes restrições:

- Identificador do cartão é obrigatório e deve ser informado na URL (path parameter).
- O email é obrigatório, ou seja, não pode ser nulo, vazio ou inválido.
- O mesmo cartão não pode ser associado mais de uma vez a mesma carteira digital, no caso aqui o Paypal.

### Resultado Esperado

- A carteira deve estar armazenada no sistema, com um identificador gerado pelo sistema.
- Retornar **201** com Header Location preenchido com a URL da carteira em caso de sucesso.
    - Quando o sistema bancário retornar sucesso (status code na faixa 200) a carteira deve ser armazenada no sistema.
    - Quando o sistema bancário retornar erro (status code na faixa 400 ou 500) a carteira não deve ser armazenada no sistema.
- Retornar **400** quando violado alguma das restrições.
- Retornar **404** quando o cartão não for encontrado.
- Retornar **422** no caso de tentativa de associação de um cartão que já era associado com a carteira
