### PR TITLE
Trace das requisição com Jaeger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.3.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>br.com.zupacademy.ggwadera</groupId>
@@ -15,7 +15,7 @@
     <description>Desafio Micro-serviço Propostas</description>
     <properties>
         <java.version>11</java.version>
-        <spring-cloud.version>2020.0.2</spring-cloud.version>
+        <spring-cloud.version>Hoxton.SR11</spring-cloud.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -64,6 +64,11 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-jaeger-cloud-starter</artifactId>
+            <version>3.3.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: proposta
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/propostas}
     username: ${DB_USER:keycloak}
@@ -26,6 +28,15 @@ management:
     web:
       exposure:
         include: info, health, prometheus
+
+opentracing:
+  jaeger:
+    enabled: ${JAEGER_ENABLED:true}
+    service-name: ${spring.application.name}
+    http-sender:
+      url: ${JAEGER_ENDPOINT:http://localhost:14268/api/traces}
+    probabilistic-sampler:
+      sampling-rate: ${JAEGER_SAMPLER:1}
 
 servicos:
   analise: ${URL_ANALISE:http://localhost:9999/api}


### PR DESCRIPTION
### Objetivo

Nossos serviços precisam se comunicar com outros serviços, isso é bastante presente nos modelos de arquiteturas atuais. 
Essas comunicações podem ser simples, um serviço chamando outro, até mais complexos como por exemplo um serviço chamando 
5 diferentes serviços. Como podemos saber identificar unicamente uma requisição e entender o comportamento dessa 
requisições durante o ciclo de vida dela?

### Descrição

Trace distribuído é uma maneira bem simples de se entender, mas também muito efetiva de nos ajudar na tarefa de 
"rastrear" os passos de uma requisição dentro da nossa infraestrutura.

A idéia consiste na criação de um ou mais identificadores externos, e repassá-lo nas chamadas entre todos os sistemas 
envolvidos. Essa técnica também ficou bastante conhecida como Correlation Id. Quando utilizamos serviços HTTP esse 
"repasse" se dá pelos HTTP Headers.

Um padrão amplamente utilizado pela comunidade e o OpenTracing ou OpenTelemetry que é mantido pela [Cloud Native 
Computing Foundation](https://www.cncf.io/). Implementações como [Jaeger](https://www.jaegertracing.io/) ou [Zipkin](https://zipkin.io/) são suportadas.

### Necessidades

Repassar headers requeridos pelo padrão OpenTracing para todas as interações entre serviços, via HTTP Headers.

### Resultado Esperado

Informações sobre tracing presente em todas as requisições.
